### PR TITLE
option to randomize fault injection seed

### DIFF
--- a/vfdynf/vrf_fault.cpp
+++ b/vfdynf/vrf_fault.cpp
@@ -550,7 +550,20 @@ fault::ProcessAttach(
     VerifierSetAPIClassName(FaultTypeClass(Type::Section), L"Section APIs");
     VerifierSetAPIClassName(FaultTypeClass(Type::Ole), L"OLE String APIs");
 
-    VerifierSetFaultInjectionSeed(g_Properties.FaultSeed);
+    if (g_Properties.FaultSeed == 0)
+    {
+        auto seed = HandleToULong(NtCurrentThreadId()) ^ NtGetTickCount();
+        auto rand = RtlRandomEx(&seed);
+        DbgPrintEx(DPFLTR_VERIFIER_ID,
+                   DPFLTR_INFO_LEVEL,
+                   "AVRF: generated and using random fault injection seed %lu\n",
+                   rand);
+        VerifierSetFaultInjectionSeed(rand);
+    }
+    else
+    {
+        VerifierSetFaultInjectionSeed(g_Properties.FaultSeed);
+    }
 
     DbgPrintEx(DPFLTR_VERIFIER_ID,
                DPFLTR_INFO_LEVEL,

--- a/vfdynf/vrf_props.cpp
+++ b/vfdynf/vrf_props.cpp
@@ -63,7 +63,7 @@ AVRF_PROPERTY_DESCRIPTOR g_Descriptors[]
         L"FaultSeed",
         &g_Properties.FaultSeed,
         sizeof(g_Properties.FaultSeed),
-        L"Seed used for fault randomization.",
+        L"Seed used for fault randomization. A value of zero will generate a random seed.",
         nullptr
     },
     { AVRF_PROPERTY_NONE, nullptr, nullptr, 0, nullptr, nullptr }


### PR DESCRIPTION
This randomizes the fault injection seed by default. This is useful when the user chooses to use probabilistic fault injection.