### PR TITLE
Fix calling convention for VerifierGetAppCallerAddress

### DIFF
--- a/include/vrfapi.h
+++ b/include/vrfapi.h
@@ -350,7 +350,7 @@ VerifierUnregisterLayer(
 
 NTSYSAPI
 PVOID
-NTAPI
+CDECL
 VerifierGetAppCallerAddress(
     _In_ PVOID ReturnAddress
     );

--- a/vrfcore/dllmain.cpp
+++ b/vrfcore/dllmain.cpp
@@ -120,7 +120,7 @@ VerifierUnregisterLayer(
 
 NTSYSAPI
 PVOID
-NTAPI
+CDECL
 VerifierGetAppCallerAddress(
     _In_ PVOID ReturnAddress
     )


### PR DESCRIPTION
The x86 version of `vfdynf` causes crashes on process initialization because the stack in `Hook_RtlAllocateHeap` gets corrupted. The stack pointer is offset by 4 bytes compared to where it should be.

Some digging reveals that this is due to `VerifierGetAppCallerAddress`. It uses `ret`, not `ret 4`, meaning it is in fact `CDECL`, not `NTAPI`.